### PR TITLE
Allow postgresql:// protocol

### DIFF
--- a/config.go
+++ b/config.go
@@ -152,7 +152,7 @@ func ParseConfig(connString string) (*Config, error) {
 
 	if connString != "" {
 		// connString may be a database URL or a DSN
-		if strings.HasPrefix(connString, "postgres://") {
+		if strings.HasPrefix(connString, "postgres://") || strings.HasPrefix(connString, "postgresql://") {
 			err := addURLSettings(settings, connString)
 			if err != nil {
 				return nil, &parseConfigError{connString: connString, msg: "failed to parse as URL", err: err}


### PR DESCRIPTION
As mentionned in postgresql official documentation both `postgres://`
and `postgresql://` protocol are allowed in connection URIs.

see:
https://www.postgresql.org/docs/11/libpq-connect.html#id-1.7.3.8.3.6