### PR TITLE
Eliminate potential races in ContextWatcher, refactor

### DIFF
--- a/internal/ctxwatch/context_watcher.go
+++ b/internal/ctxwatch/context_watcher.go
@@ -2,6 +2,7 @@ package ctxwatch
 
 import (
 	"context"
+	"sync/atomic"
 )
 
 // ContextWatcher watches a context and performs an action when the context is canceled. It can watch one context at a
@@ -9,9 +10,8 @@ import (
 type ContextWatcher struct {
 	onCancel             func()
 	onUnwatchAfterCancel func()
-	unwatchChan          chan struct{}
-	watchInProgress      bool
-	onCancelWasCalled    bool
+	canceled             chan bool
+	watching             uint32
 }
 
 // NewContextWatcher returns a ContextWatcher. onCancel will be called when a watched context is canceled.
@@ -21,7 +21,7 @@ func NewContextWatcher(onCancel func(), onUnwatchAfterCancel func()) *ContextWat
 	cw := &ContextWatcher{
 		onCancel:             onCancel,
 		onUnwatchAfterCancel: onUnwatchAfterCancel,
-		unwatchChan:          make(chan struct{}),
+		canceled:             make(chan bool),
 	}
 
 	return cw
@@ -29,36 +29,41 @@ func NewContextWatcher(onCancel func(), onUnwatchAfterCancel func()) *ContextWat
 
 // Watch starts watching ctx. If ctx is canceled then the onCancel function passed to NewContextWatcher will be called.
 func (cw *ContextWatcher) Watch(ctx context.Context) {
-	if cw.watchInProgress {
+	if swapped := atomic.CompareAndSwapUint32(&cw.watching, 0, 1); !swapped {
 		panic("Watch already in progress")
 	}
 
-	cw.onCancelWasCalled = false
+	if ctx.Done() == nil {
+		cw.watching = 0 // Known to be not watching, so no need for an atomic store.
+		return
+	}
 
-	if ctx.Done() != nil {
-		cw.watchInProgress = true
-		go func() {
-			select {
-			case <-ctx.Done():
-				cw.onCancel()
-				cw.onCancelWasCalled = true
-				<-cw.unwatchChan
-			case <-cw.unwatchChan:
-			}
-		}()
-	} else {
-		cw.watchInProgress = false
+	go cw.watch(ctx)
+}
+
+func (cw *ContextWatcher) watch(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+		watching := atomic.LoadUint32(&cw.watching) == 1
+		if watching {
+			cw.onCancel()
+		}
+		cw.canceled <- watching
+
+	case cw.canceled <- false:
 	}
 }
 
 // Unwatch stops watching the previously watched context. If the onCancel function passed to NewContextWatcher was
 // called then onUnwatchAfterCancel will also be called.
 func (cw *ContextWatcher) Unwatch() {
-	if cw.watchInProgress {
-		cw.unwatchChan <- struct{}{}
-		if cw.onCancelWasCalled {
-			cw.onUnwatchAfterCancel()
-		}
-		cw.watchInProgress = false
+	watching := atomic.CompareAndSwapUint32(&cw.watching, 1, 0)
+	if !watching {
+		return
+	}
+
+	canceled := <-cw.canceled
+	if canceled {
+		cw.onUnwatchAfterCancel()
 	}
 }


### PR DESCRIPTION
Fixes #25.

Instead of bare booleans, use an atomic value which indicates if the context is being watched. Switch `onCancelWasCalled` and `unwatchChan` to a `chan bool` which communicates if `onUnwatchAfterCancel` has been called.

Modeled on paper with a state machine to ensure that the semantics of this watcher match the original intent. I find the new code to be a little more readable.

I'm fairly confident this eliminates race potential (https://github.com/hortbot/hortbot/runs/385472775 w/ my fork). I'm not entirely certain why the existing tests didn't fail in race mode, but maybe the race required concurrent callers to `Unwatch` or similar or a specific cancellation setup.

`benchstat` of this change:

```
name                           old time/op    new time/op    delta
ContextWatcherUncancellable-4    3.73ns ± 0%   16.23ns ± 1%  +335.56%  (p=0.000 n=8+10)
ContextWatcherCancelled-4         713ns ± 1%     760ns ± 2%    +6.57%  (p=0.000 n=10+10)
ContextWatcherCancellable-4       454ns ± 1%     479ns ± 0%    +5.65%  (p=0.000 n=10+9)

name                           old alloc/op   new alloc/op   delta
ContextWatcherUncancellable-4     0.00B          0.00B           ~     (all equal)
ContextWatcherCancelled-4          176B ± 0%      176B ± 0%      ~     (all equal)
ContextWatcherCancellable-4       0.00B          0.00B           ~     (all equal)

name                           old allocs/op  new allocs/op  delta
ContextWatcherUncancellable-4      0.00           0.00           ~     (all equal)
ContextWatcherCancelled-4          3.00 ± 0%      3.00 ± 0%      ~     (all equal)
ContextWatcherCancellable-4        0.00           0.00           ~     (all equal)
```

Small overall penalty for the atomic instructions. `ContextWatcherUncancellable` is impacted the most as I preserved the behavior that `Watch` should panic if it's already watching, even if `ctx.Done() == nil`. If you don't care about panicking if the new context cannot be canceled, I'm sure I can lower this, but we're already working at incredibly small timescales.