### PR TITLE
Add functions to check if an error is a given pgconn error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -79,6 +79,11 @@ func (e *connectError) Unwrap() error {
 	return e.err
 }
 
+func IsConnectError(err error) bool {
+	_, ok := err.(*connectError)
+	return ok
+}
+
 type connLockError struct {
 	status string
 }
@@ -89,6 +94,11 @@ func (e *connLockError) SafeToRetry() bool {
 
 func (e *connLockError) Error() string {
 	return e.status
+}
+
+func IsConnLockError(err error) bool {
+	_, ok := err.(*connLockError)
+	return ok
 }
 
 type parseConfigError struct {
@@ -106,6 +116,11 @@ func (e *parseConfigError) Error() string {
 
 func (e *parseConfigError) Unwrap() error {
 	return e.err
+}
+
+func IsParseConfigError(err error) bool {
+	_, ok := err.(*parseConfigError)
+	return ok
 }
 
 type pgconnError struct {
@@ -132,6 +147,11 @@ func (e *pgconnError) Unwrap() error {
 	return e.err
 }
 
+func IsPgConnError(err error) bool {
+	_, ok := err.(*pgconnError)
+	return ok
+}
+
 type contextAlreadyDoneError struct {
 	err error
 }
@@ -146,6 +166,11 @@ func (e *contextAlreadyDoneError) SafeToRetry() bool {
 
 func (e *contextAlreadyDoneError) Unwrap() error {
 	return e.err
+}
+
+func IsContextAlreadyDoneError(err error) bool {
+	_, ok := err.(*contextAlreadyDoneError)
+	return ok
 }
 
 type writeError struct {
@@ -163,4 +188,9 @@ func (e *writeError) SafeToRetry() bool {
 
 func (e *writeError) Unwrap() error {
 	return e.err
+}
+
+func IsWriteError(err error) bool {
+	_, ok := err.(*writeError)
+	return ok
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,51 @@
+package pgconn
+
+import (
+    "errors"
+    "io"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestIsConnectError(t *testing.T) {
+    err := &connectError{msg: "-"}
+    assert.True(t, IsConnectError(err))
+
+    assert.False(t, IsConnectError(io.EOF))
+}
+
+func TestIsConnLockError(t *testing.T) {
+    err := &connLockError{status: "-"}
+    assert.True(t, IsConnLockError(err))
+
+    assert.False(t, IsConnLockError(io.EOF))
+}
+
+func TestIsParseConfigError(t *testing.T) {
+    err := &parseConfigError{msg: "-"}
+    assert.True(t, IsParseConfigError(err))
+
+    assert.False(t, IsParseConfigError(io.EOF))
+}
+
+func TestIsPgConnError(t *testing.T) {
+    err := &pgconnError{msg: "-"}
+    assert.True(t, IsPgConnError(err))
+
+    assert.False(t, IsPgConnError(io.EOF))
+}
+
+func TestIsContextAlreadyDoneError(t *testing.T) {
+    err := &contextAlreadyDoneError{err: errors.New("-")}
+    assert.True(t, IsContextAlreadyDoneError(err))
+
+    assert.False(t, IsContextAlreadyDoneError(io.EOF))
+}
+
+func TestIsWriteError(t *testing.T) {
+    err := &writeError{err: errors.New("-")}
+    assert.True(t, IsWriteError(err))
+
+    assert.False(t, IsWriteError(io.EOF))
+}


### PR DESCRIPTION
I have a need to check whether an error is a `pgconn.writeError` or `pgconn.connLockError` for a project, but these errors are not exported. 