### PR TITLE
Implement "verify-ca" SSL mode

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -132,7 +132,9 @@ func TestParseConfig(t *testing.T) {
 				Host:          "localhost",
 				Port:          5432,
 				Database:      "mydb",
-				TLSConfig:     &tls.Config{ServerName: "localhost"},
+				TLSConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
 				RuntimeParams: map[string]string{},
 			},
 		},


### PR DESCRIPTION
I came across a situation with Google Cloud SQL where I needed the behavior of "verify-ca" because "verify-full" was too strict. Specifically, Postgres instances on GCP typically don't have a hostname and use their own private CA when signing certs. This causes the TLS handshake to fail if you attempt to connect via IP:

> failed to connect to `host=xx.xx.xx.xxx user=postgres database=postgres`: failed to write startup message (x509: cannot validate certificate for xx.xx.xx.xxx because it doesn't contain any IP SANs)

Since the CA is private, checking the server name is unnecessary, and [Google's docs recommend using "verify-ca"][1].

I found a solution by setting InsecureSkipVerify to true and setting a VerifyPeerCertificate function in the tls.Config returned by ParseConfig. Basically, VerifyPeerCertificate manually verifies the cert chain, but skips checking the hostname. You can see https://github.com/golang/go/issues/21971#issuecomment-332693931 and the [crypto/tls package example][2] for more details on how this is implemented.

Since this wasn't super straightforward to figure out, I thought I'd see if you wanted it upstream. I also poked around and couldn't find a way to write a test the new SSL behavior, but I did test everything manually for my use-case.

[1]: https://cloud.google.com/sql/docs/postgres/connect-admin-ip#connect-ssl
[2]: https://pkg.go.dev/crypto/tls?tab=doc#example-Config-VerifyPeerCertificate