### PR TITLE
Fix DSN parsing

### DIFF
--- a/config.go
+++ b/config.go
@@ -444,9 +444,13 @@ func parseDSNSettings(s string) (map[string]string, error) {
 
 		key = strings.Trim(s[:eqIdx], " \t\n\r\v\f")
 		s = strings.TrimLeft(s[eqIdx+1:], " \t\n\r\v\f")
-		if s[0] != '\'' {
+		if len(s) == 0 || s[0] != '\'' {
 			end := 0
 			for ; end < len(s); end++ {
+				if s[end] == '=' {
+					end = -1
+					break
+				}
 				if asciiSpace[s[end]] == 1 {
 					break
 				}
@@ -454,7 +458,9 @@ func parseDSNSettings(s string) (map[string]string, error) {
 					end++
 				}
 			}
-			val = strings.Replace(strings.Replace(s[:end], "\\\\", "\\", -1), "\\'", "'", -1)
+			if end >= 0 {
+				val = strings.Replace(strings.Replace(s[:end], "\\\\", "\\", -1), "\\'", "'", -1)
+			}
 			if end == len(s) {
 				s = ""
 			} else {

--- a/config_test.go
+++ b/config_test.go
@@ -127,11 +127,11 @@ func TestParseConfig(t *testing.T) {
 			name:       "sslmode verify-ca",
 			connString: "postgres://jack:secret@localhost:5432/mydb?sslmode=verify-ca",
 			config: &pgconn.Config{
-				User:          "jack",
-				Password:      "secret",
-				Host:          "localhost",
-				Port:          5432,
-				Database:      "mydb",
+				User:     "jack",
+				Password: "secret",
+				Host:     "localhost",
+				Port:     5432,
+				Database: "mydb",
 				TLSConfig: &tls.Config{
 					InsecureSkipVerify: true,
 				},
@@ -245,6 +245,45 @@ func TestParseConfig(t *testing.T) {
 			},
 		},
 		{
+			name:       "DSN with empty string values",
+			connString: "user= password= host= port=5432 dbname= sslmode=disable",
+			config: &pgconn.Config{
+				User:          "",
+				Password:      "",
+				Host:          "",
+				Port:          5432,
+				Database:      "",
+				TLSConfig:     nil,
+				RuntimeParams: map[string]string{},
+			},
+		},
+		{
+			name:       "DSN with empty string value for the last param",
+			connString: "user=jack password=secret host=localhost sslmode=disable dbname=",
+			config: &pgconn.Config{
+				User:          "jack",
+				Password:      "secret",
+				Host:          "localhost",
+				Port:          5432,
+				Database:      "",
+				TLSConfig:     nil,
+				RuntimeParams: map[string]string{},
+			},
+		},
+		{
+			name:       "DSN with space between key and value",
+			connString: "user = jack password = secret host = localhost dbname = mydb sslmode = disable",
+			config: &pgconn.Config{
+				User:          "jack",
+				Password:      "secret",
+				Host:          "localhost",
+				Port:          5432,
+				Database:      "mydb",
+				TLSConfig:     nil,
+				RuntimeParams: map[string]string{},
+			},
+		},
+		{
 			name:       "DSN with escaped single quote",
 			connString: "user=jack\\'s password=secret host=localhost port=5432 dbname=mydb sslmode=disable",
 			config: &pgconn.Config{
@@ -307,8 +346,8 @@ func TestParseConfig(t *testing.T) {
 			},
 		},
 		{
-			name:       "DSN with space between key and value",
-			connString: "user = 'jack' password = '' host = 'localhost' dbname = 'mydb' sslmode='disable'",
+			name:       "DSN with space between key and single quoted value",
+			connString: "user = 'jack' password = '' host = 'localhost' dbname = 'mydb' sslmode = 'disable'",
 			config: &pgconn.Config{
 				User:          "jack",
 				Host:          "localhost",


### PR DESCRIPTION
- When 'param1= param2=value2' was passed, the parsed value of param1
  was 'param2=value2', and not '' as expected.

- Fix crash (index out of range [0] with length 0) when empty value
  was given for the last param of the DSN string.