### PR TITLE
Ensure the example code snippet compiles again

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ pgConn, err := pgconn.Connect(context.Background(), os.Getenv("DATABASE_URL"))
 if err != nil {
 	log.Fatalln("pgconn failed to connect:", err)
 }
-defer pgConn.Close()
+defer pgConn.Close(context.Background())
 
 result := pgConn.ExecParams(context.Background(), "SELECT email FROM users WHERE id=$1", [][]byte{[]byte("123")}, nil, nil, nil)
 for result.NextRow() {
 	fmt.Println("User 123 has email:", string(result.Values()[0]))
 }
-_, err := result.Close()
+_, err = result.Close()
 if err != nil {
 	log.Fatalln("failed reading result:", err)
-})
+}
 ```
 
 ## Testing


### PR DESCRIPTION
There were 2 errors when using the example code:

- not enough arguments in call to pgConn.Close
- no new variables on left side of :=

With these changes, the example works again.