### PR TITLE
Prevent sending Cancel to an already closed connection

### DIFF
--- a/pgconn.go
+++ b/pgconn.go
@@ -573,7 +573,9 @@ func (pgConn *PgConn) asyncClose() {
 		ctx, cancel := context.WithDeadline(context.Background(), deadline)
 		defer cancel()
 
-		pgConn.CancelRequest(ctx)
+		if pgConn.status != connStatusClosed {
+			pgConn.CancelRequest(ctx)
+		}
 
 		pgConn.conn.SetDeadline(deadline)
 


### PR DESCRIPTION
When connecting using this library, without good credentials, the
following would show up in the logs of the PostgreSQL server:

00000,"connection received: host=127.0.0.1 port=36730"
00000,"PID 0 in cancel request did not match any process"
28P01,"password authentication failed for user ""postgres"""

The error message about PID 0 is generated by processCancelRequest[1],
as there is no backend associated with this connection.

We should therefore take care not to send a CancelRequest to an already
closed connection.

1: https://github.com/postgres/postgres/blob/master/src/backend/postmaster/postmaster.c