### PR TITLE
stmtcache: add new ClearStmt method

### DIFF
--- a/stmtcache/lru_test.go
+++ b/stmtcache/lru_test.go
@@ -53,6 +53,11 @@ func TestLRUModePrepare(t *testing.T) {
 	require.EqualValues(t, 2, cache.Len())
 	require.ElementsMatch(t, []string{"select 2", "select 3"}, fetchServerStatements(t, ctx, conn))
 
+	err = cache.ClearStmt(ctx, "select 2")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, cache.Len())
+	require.ElementsMatch(t, []string{"select 3"}, fetchServerStatements(t, ctx, conn))
+
 	err = cache.Clear(ctx)
 	require.NoError(t, err)
 	require.EqualValues(t, 0, cache.Len())
@@ -120,6 +125,11 @@ func TestLRUModeDescribe(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, psd)
 	require.EqualValues(t, 2, cache.Len())
+	require.Empty(t, fetchServerStatements(t, ctx, conn))
+
+	err = cache.ClearStmt(ctx, "select 2")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, cache.Len())
 	require.Empty(t, fetchServerStatements(t, ctx, conn))
 
 	err = cache.Clear(ctx)

--- a/stmtcache/stmtcache.go
+++ b/stmtcache/stmtcache.go
@@ -20,6 +20,11 @@ type Cache interface {
 	// Clear removes all entries in the cache. Any prepared statements will be deallocated from the PostgreSQL session.
 	Clear(ctx context.Context) error
 
+	// ClearStmt removes a single entry from the cache.
+	// Any prepared statements will be deallocated from the PostgreSQL session.
+	// The underlying *pgconn.PgConn MUST NOT be in the middle of a transaction.
+	ClearStmt(ctx context.Context, sql string) error
+
 	// Len returns the number of cached prepared statement descriptions.
 	Len() int
 


### PR DESCRIPTION
This patch adds a new routine to the stmtcache/stmtcache.go
Cache interface allow users to clear a specific statement from
the cache, rather than clobbering the whole cace.

This change is in order to allow the fix discussed in
https://github.com/jackc/pgx/issues/841