### PR TITLE
Expose ResultReader.Err() to allow row iteration to check for errors

### DIFF
--- a/pgconn.go
+++ b/pgconn.go
@@ -1413,6 +1413,10 @@ func (rr *ResultReader) Read() *Result {
 	return br
 }
 
+func (rr *ResultReader) Err() error {
+	return rr.err
+}
+
 // NextRow advances the ResultReader to the next row and returns true if a row is available.
 func (rr *ResultReader) NextRow() bool {
 	for !rr.commandConcluded {


### PR DESCRIPTION
Required by https://github.com/jackc/pgx/pull/870