### PR TITLE
Add check for url with broken password

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -178,6 +178,8 @@ func redactPW(connString string) string {
 	connString = quotedDSN.ReplaceAllLiteralString(connString, "password=xxxxx")
 	plainDSN := regexp.MustCompile(`password=[^ ]*`)
 	connString = plainDSN.ReplaceAllLiteralString(connString, "password=xxxxx")
+	brokenURL := regexp.MustCompile(`:\w.*@`)
+	connString = brokenURL.ReplaceAllLiteralString(connString, ":xxxxxx@")
 	return connString
 }
 

--- a/errors.go
+++ b/errors.go
@@ -178,7 +178,7 @@ func redactPW(connString string) string {
 	connString = quotedDSN.ReplaceAllLiteralString(connString, "password=xxxxx")
 	plainDSN := regexp.MustCompile(`password=[^ ]*`)
 	connString = plainDSN.ReplaceAllLiteralString(connString, "password=xxxxx")
-	brokenURL := regexp.MustCompile(`:\w.*@`)
+	brokenURL := regexp.MustCompile(`:[^:@]+?@`)
 	connString = brokenURL.ReplaceAllLiteralString(connString, ":xxxxxx@")
 	return connString
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -33,6 +33,16 @@ func TestConfigError(t *testing.T) {
 			err:         pgconn.NewParseConfigError("postgresql://foo::pasword@host:1:", "msg", nil),
 			expectedMsg: "cannot parse `postgresql://foo:xxxxx@host:1:`: msg",
 		},
+		{
+			name:        "weird url with slash in password",
+			err:         pgconn.NewParseConfigError("postgres://user:pass/word@host:5432/db_name", "msg", nil),
+			expectedMsg: "cannot parse `postgres://user:xxxxxx@host:5432/db_name`: msg",
+		},
+		{
+			name:        "url without password",
+			err:         pgconn.NewParseConfigError("postgresql://other@host/db", "msg", nil),
+			expectedMsg: "cannot parse `postgresql://other@host/db`: msg",
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
Resolves #51. Replace broken password in parseConfigError message.