### PR TITLE
Use proper pgpass location on Windows

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -336,48 +335,6 @@ func ParseConfig(connString string) (*Config, error) {
 	}
 
 	return config, nil
-}
-
-func defaultSettings() map[string]string {
-	settings := make(map[string]string)
-
-	settings["host"] = defaultHost()
-	settings["port"] = "5432"
-
-	// Default to the OS user name. Purposely ignoring err getting user name from
-	// OS. The client application will simply have to specify the user in that
-	// case (which they typically will be doing anyway).
-	user, err := user.Current()
-	if err == nil {
-		settings["user"] = user.Username
-		settings["passfile"] = filepath.Join(user.HomeDir, ".pgpass")
-		settings["servicefile"] = filepath.Join(user.HomeDir, ".pg_service.conf")
-	}
-
-	settings["target_session_attrs"] = "any"
-
-	settings["min_read_buffer_size"] = "8192"
-
-	return settings
-}
-
-// defaultHost attempts to mimic libpq's default host. libpq uses the default unix socket location on *nix and localhost
-// on Windows. The default socket location is compiled into libpq. Since pgx does not have access to that default it
-// checks the existence of common locations.
-func defaultHost() string {
-	candidatePaths := []string{
-		"/var/run/postgresql", // Debian
-		"/private/tmp",        // OSX - homebrew
-		"/tmp",                // standard PostgreSQL
-	}
-
-	for _, path := range candidatePaths {
-		if _, err := os.Stat(path); err == nil {
-			return path
-		}
-	}
-
-	return "localhost"
 }
 
 func mergeSettings(settingSets ...map[string]string) map[string]string {

--- a/config_test.go
+++ b/config_test.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"os"
 	"os/user"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,7 +23,13 @@ func TestParseConfig(t *testing.T) {
 	var osUserName string
 	osUser, err := user.Current()
 	if err == nil {
-		osUserName = osUser.Username
+		// Windows gives us the username here as `DOMAIN\user` or `LOCALPCNAME\user`,
+		// but the libpq default is just the `user` portion, so we strip off the first part.
+		if runtime.GOOS == "windows" && strings.Contains(osUser.Username, "\\") {
+			osUserName = osUser.Username[strings.LastIndex(osUser.Username, "\\")+1:]
+		} else {
+			osUserName = osUser.Username
+		}
 	}
 
 	tests := []struct {
@@ -630,7 +638,13 @@ func TestParseConfigEnvLibpq(t *testing.T) {
 	var osUserName string
 	osUser, err := user.Current()
 	if err == nil {
-		osUserName = osUser.Username
+		// Windows gives us the username here as `DOMAIN\user` or `LOCALPCNAME\user`,
+		// but the libpq default is just the `user` portion, so we strip off the first part.
+		if runtime.GOOS == "windows" && strings.Contains(osUser.Username, "\\") {
+			osUserName = osUser.Username[strings.LastIndex(osUser.Username, "\\")+1:]
+		} else {
+			osUserName = osUser.Username
+		}
 	}
 
 	pgEnvvars := []string{"PGHOST", "PGPORT", "PGDATABASE", "PGUSER", "PGPASSWORD", "PGAPPNAME", "PGSSLMODE", "PGCONNECT_TIMEOUT"}

--- a/defaults.go
+++ b/defaults.go
@@ -1,0 +1,51 @@
+// +build !windows
+
+package pgconn
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+)
+
+func defaultSettings() map[string]string {
+	settings := make(map[string]string)
+
+	settings["host"] = defaultHost()
+	settings["port"] = "5432"
+
+	// Default to the OS user name. Purposely ignoring err getting user name from
+	// OS. The client application will simply have to specify the user in that
+	// case (which they typically will be doing anyway).
+	user, err := user.Current()
+	if err == nil {
+		settings["user"] = user.Username
+		settings["passfile"] = filepath.Join(user.HomeDir, ".pgpass")
+		settings["servicefile"] = filepath.Join(user.HomeDir, ".pg_service.conf")
+	}
+
+	settings["target_session_attrs"] = "any"
+
+	settings["min_read_buffer_size"] = "8192"
+
+	return settings
+}
+
+// defaultHost attempts to mimic libpq's default host. libpq uses the default unix socket location on *nix and localhost
+// on Windows. The default socket location is compiled into libpq. Since pgx does not have access to that default it
+// checks the existence of common locations.
+func defaultHost() string {
+	candidatePaths := []string{
+		"/var/run/postgresql", // Debian
+		"/private/tmp",        // OSX - homebrew
+		"/tmp",                // standard PostgreSQL
+	}
+
+	for _, path := range candidatePaths {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+
+	return "localhost"
+}

--- a/defaults_windows.go
+++ b/defaults_windows.go
@@ -1,0 +1,46 @@
+package pgconn
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+)
+
+func defaultSettings() map[string]string {
+	settings := make(map[string]string)
+
+	settings["host"] = defaultHost()
+	settings["port"] = "5432"
+
+	// Default to the OS user name. Purposely ignoring err getting user name from
+	// OS. The client application will simply have to specify the user in that
+	// case (which they typically will be doing anyway).
+	user, err := user.Current()
+	appData := os.Getenv("APPDATA")
+	if err == nil {
+		// Windows gives us the username here as `DOMAIN\user` or `LOCALPCNAME\user`,
+		// but the libpq default is just the `user` portion, so we strip off the first part.
+		username := user.Username
+		if strings.Contains(username, "\\") {
+			username = username[strings.LastIndex(username, "\\")+1:]
+		}
+
+		settings["user"] = username
+		settings["passfile"] = filepath.Join(appData, "postgresql", "pgpass.conf")
+		settings["servicefile"] = filepath.Join(user.HomeDir, ".pg_service.conf")
+	}
+
+	settings["target_session_attrs"] = "any"
+
+	settings["min_read_buffer_size"] = "8192"
+
+	return settings
+}
+
+// defaultHost attempts to mimic libpq's default host. libpq uses the default unix socket location on *nix and localhost
+// on Windows. The default socket location is compiled into libpq. Since pgx does not have access to that default it
+// checks the existence of common locations.
+func defaultHost() string {
+	return "localhost"
+}


### PR DESCRIPTION
Fixes #60

Includes updating the logic used to get the default username if none is provided.