### PR TITLE
Return ErrorResponse from backend if it preceed transport error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -49,6 +49,7 @@ type PgError struct {
 	File             string
 	Line             int32
 	Routine          string
+	NetworkError     error
 }
 
 func (pe *PgError) Error() string {

--- a/pgconn.go
+++ b/pgconn.go
@@ -1204,7 +1204,11 @@ func (mrr *MultiResultReader) receiveMessage() (pgproto3.BackendMessage, error) 
 
 	if err != nil {
 		mrr.pgConn.contextWatcher.Unwatch()
-		mrr.err = err
+		if x, ok := mrr.err.(*PgError); ok {
+			x.NetworkError = err
+		} else {
+			mrr.err = err
+		}
 		mrr.closed = true
 		mrr.pgConn.asyncClose()
 		return nil, mrr.err


### PR DESCRIPTION
Fix for #63 

I'm a little bit in doubt here: the connection is actually closed after returning this error. Is there a way to signal this to the user within error?