### PR TITLE
Resume fallback on server error

### DIFF
--- a/pgconn.go
+++ b/pgconn.go
@@ -141,6 +141,10 @@ func ConnectConfig(ctx context.Context, config *Config) (pgConn *PgConn, err err
 			break
 		} else if pgerr, ok := err.(*PgError); ok {
 			err = &connectError{config: config, msg: "server error", err: pgerr}
+			ERRCODE_INVALID_PASSWORD := "28P01"
+			if pgerr.Code == ERRCODE_INVALID_PASSWORD {
+				break;
+			}
 		}
 	}
 

--- a/pgconn.go
+++ b/pgconn.go
@@ -140,7 +140,7 @@ func ConnectConfig(ctx context.Context, config *Config) (pgConn *PgConn, err err
 		if err == nil {
 			break
 		} else if err, ok := err.(*PgError); ok {
-			return nil, &connectError{config: config, msg: "server error", err: err}
+			err = &connectError{config: config, msg: "server error", err: err}
 		}
 	}
 

--- a/pgconn.go
+++ b/pgconn.go
@@ -139,8 +139,8 @@ func ConnectConfig(ctx context.Context, config *Config) (pgConn *PgConn, err err
 		pgConn, err = connect(ctx, config, fc)
 		if err == nil {
 			break
-		} else if err, ok := err.(*PgError); ok {
-			err = &connectError{config: config, msg: "server error", err: err}
+		} else if pgerr, ok := err.(*PgError); ok {
+			err = &connectError{config: config, msg: "server error", err: pgerr}
 		}
 	}
 

--- a/pgconn.go
+++ b/pgconn.go
@@ -141,9 +141,10 @@ func ConnectConfig(ctx context.Context, config *Config) (pgConn *PgConn, err err
 			break
 		} else if pgerr, ok := err.(*PgError); ok {
 			err = &connectError{config: config, msg: "server error", err: pgerr}
-			ERRCODE_INVALID_PASSWORD := "28P01"
-			if pgerr.Code == ERRCODE_INVALID_PASSWORD {
-				break;
+			ERRCODE_INVALID_PASSWORD := "28P01"                    // worng password
+			ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION := "28000" // db does not exist
+			if pgerr.Code == ERRCODE_INVALID_PASSWORD || pgerr.Code == ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION {
+				break
 			}
 		}
 	}


### PR DESCRIPTION
When server responds with "TLS required" or too "many connections for role" fallbacks are not traversed any further. This could be OK, but fallbacks without TLS are added autoatically so that if we have multiple hosts requiring TLS we never traverse beyond first one.