### PR TITLE
Solve issue with 'sslmode=verify-full' when there are multiple hosts

### DIFF
--- a/config.go
+++ b/config.go
@@ -297,7 +297,7 @@ func ParseConfig(connString string) (*Config, error) {
 			tlsConfigs = append(tlsConfigs, nil)
 		} else {
 			var err error
-			tlsConfigs, err = configTLS(settings)
+			tlsConfigs, err = configTLS(settings, host)
 			if err != nil {
 				return nil, &parseConfigError{connString: connString, msg: "failed to configure TLS", err: err}
 			}
@@ -552,8 +552,8 @@ func parseServiceSettings(servicefilePath, serviceName string) (map[string]strin
 // configTLS uses libpq's TLS parameters to construct  []*tls.Config. It is
 // necessary to allow returning multiple TLS configs as sslmode "allow" and
 // "prefer" allow fallback.
-func configTLS(settings map[string]string) ([]*tls.Config, error) {
-	host := settings["host"]
+func configTLS(settings map[string]string, thisHost string) ([]*tls.Config, error) {
+	host := thisHost
 	sslmode := settings["sslmode"]
 	sslrootcert := settings["sslrootcert"]
 	sslcert := settings["sslcert"]


### PR DESCRIPTION
After following up on https://github.com/jackc/pgx/issues/1025, it seems the root cause of the problem was here, in the pgconn repo.  This is just a change to three lines which properly passes in the correct host value to the function which creates the TLS configs.
