### PR TITLE
Add defaults for sslcert and sslkey

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -22,6 +22,8 @@ func defaultSettings() map[string]string {
 		settings["user"] = user.Username
 		settings["passfile"] = filepath.Join(user.HomeDir, ".pgpass")
 		settings["servicefile"] = filepath.Join(user.HomeDir, ".pg_service.conf")
+		settings["sslcert"] = filepath.Join(user.HomeDir, ".postgresql", "postgresql.crt")
+		settings["sslkey"] = filepath.Join(user.HomeDir, ".postgresql", "postgresql.key")
 	}
 
 	settings["target_session_attrs"] = "any"

--- a/defaults_windows.go
+++ b/defaults_windows.go
@@ -29,6 +29,8 @@ func defaultSettings() map[string]string {
 		settings["user"] = username
 		settings["passfile"] = filepath.Join(appData, "postgresql", "pgpass.conf")
 		settings["servicefile"] = filepath.Join(user.HomeDir, ".pg_service.conf")
+		settings["sslcert"] = filepath.Join(appData, "postgresql", "postgresql.crt")
+		settings["sslkey"] = filepath.Join(appData, "postgresql", "postgresql.key")
 	}
 
 	settings["target_session_attrs"] = "any"


### PR DESCRIPTION
per https://www.postgresql.org/docs/current/libpq-ssl.html
psql will use client certs located in ~/.postgresql on posix systems
or %APPDATA%\postgresql on Windows systems.