### PR TITLE
Add defaults for sslcert, sslkey, and sslrootcert

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -22,6 +22,19 @@ func defaultSettings() map[string]string {
 		settings["user"] = user.Username
 		settings["passfile"] = filepath.Join(user.HomeDir, ".pgpass")
 		settings["servicefile"] = filepath.Join(user.HomeDir, ".pg_service.conf")
+		sslcert := filepath.Join(user.HomeDir, ".postgresql", "postgresql.crt")
+		sslkey := filepath.Join(user.HomeDir, ".postgresql", "postgresql.key")
+		if _, err := os.Stat(sslcert); err == nil {
+			if _, err := os.Stat(sslkey); err == nil {
+				// Both the cert and key must be present to use them, or do not use either
+				settings["sslcert"] = sslcert
+				settings["sslkey"] = sslkey
+			}
+		}
+		sslrootcert := filepath.Join(user.HomeDir, ".postgresql", "root.crt")
+		if _, err := os.Stat(sslrootcert); err == nil {
+			settings["sslrootcert"] = sslrootcert
+		}
 	}
 
 	settings["target_session_attrs"] = "any"

--- a/defaults_windows.go
+++ b/defaults_windows.go
@@ -29,6 +29,19 @@ func defaultSettings() map[string]string {
 		settings["user"] = username
 		settings["passfile"] = filepath.Join(appData, "postgresql", "pgpass.conf")
 		settings["servicefile"] = filepath.Join(user.HomeDir, ".pg_service.conf")
+		sslcert := filepath.Join(appData, "postgresql", "postgresql.crt")
+		sslkey := filepath.Join(appData, "postgresql", "postgresql.key")
+		if _, err := os.Stat(sslcert); err == nil {
+			if _, err := os.Stat(sslkey); err == nil {
+				// Both the cert and key must be present to use them, or do not use either
+				settings["sslcert"] = sslcert
+				settings["sslkey"] = sslkey
+			}
+		}
+		sslrootcert := filepath.Join(appData, "postgresql", "root.crt")
+		if _, err := os.Stat(sslrootcert); err == nil {
+			settings["sslrootcert"] = sslrootcert
+		}
 	}
 
 	settings["target_session_attrs"] = "any"


### PR DESCRIPTION
per https://www.postgresql.org/docs/current/libpq-ssl.html
psql will use client certs located in ~/.postgresql on posix systems
or %APPDATA%\postgresql on Windows systems.