### PR TITLE
Implement timeout error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -163,15 +163,9 @@ func (e *contextAlreadyDoneError) Unwrap() error {
 	return e.err
 }
 
-// newContextAlreadyDoneError wraps a context error in `contextAlreadyDoneError`. If the context was cancelled or its
-// deadline passed, the returned error is also wrapped by `ErrTimeout`.
+// newContextAlreadyDoneError double-wraps a context error in `contextAlreadyDoneError` and `ErrTimeout`.
 func newContextAlreadyDoneError(ctx context.Context) (err error) {
-	ctxErr := ctx.Err()
-	err = &contextAlreadyDoneError{err: ctxErr}
-	if ctxErr != nil {
-		err = &ErrTimeout{err: err}
-	}
-	return err
+	return &ErrTimeout{&contextAlreadyDoneError{err: ctx.Err()}}
 }
 
 type writeError struct {

--- a/errors.go
+++ b/errors.go
@@ -20,7 +20,7 @@ func SafeToRetry(err error) bool {
 // Timeout checks if err was was caused by a timeout. To be specific, it is true if err was caused within pgconn by a
 // context.Canceled, context.DeadlineExceeded or an implementer of net.Error where Timeout() is true.
 func Timeout(err error) bool {
-	var timeoutErr *ErrTimeout
+	var timeoutErr *errTimeout
 	return errors.As(err, &timeoutErr)
 }
 
@@ -129,21 +129,21 @@ func (e *pgconnError) Unwrap() error {
 	return e.err
 }
 
-// ErrTimeout occurs when an error was caused by a timeout. Specifically, it wraps an error which is
+// errTimeout occurs when an error was caused by a timeout. Specifically, it wraps an error which is
 // context.Canceled, context.DeadlineExceeded, or an implementer of net.Error where Timeout() is true.
-type ErrTimeout struct {
+type errTimeout struct {
 	err error
 }
 
-func (e *ErrTimeout) Error() string {
+func (e *errTimeout) Error() string {
 	return fmt.Sprintf("timeout: %s", e.err.Error())
 }
 
-func (e *ErrTimeout) SafeToRetry() bool {
+func (e *errTimeout) SafeToRetry() bool {
 	return SafeToRetry(e.err)
 }
 
-func (e *ErrTimeout) Unwrap() error {
+func (e *errTimeout) Unwrap() error {
 	return e.err
 }
 
@@ -163,9 +163,9 @@ func (e *contextAlreadyDoneError) Unwrap() error {
 	return e.err
 }
 
-// newContextAlreadyDoneError double-wraps a context error in `contextAlreadyDoneError` and `ErrTimeout`.
+// newContextAlreadyDoneError double-wraps a context error in `contextAlreadyDoneError` and `errTimeout`.
 func newContextAlreadyDoneError(ctx context.Context) (err error) {
-	return &ErrTimeout{&contextAlreadyDoneError{err: ctx.Err()}}
+	return &errTimeout{&contextAlreadyDoneError{err: ctx.Err()}}
 }
 
 type writeError struct {

--- a/errors.go
+++ b/errors.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/url"
 	"regexp"
 	"strings"
@@ -141,15 +140,7 @@ func (e *ErrTimeout) Error() string {
 }
 
 func (e *ErrTimeout) SafeToRetry() bool {
-	var ctxErr *contextAlreadyDoneError
-	if errors.As(e, &ctxErr) {
-		return ctxErr.SafeToRetry()
-	}
-	var netErr net.Error
-	if errors.As(e, &netErr) {
-		return netErr.Temporary()
-	}
-	return false
+	return SafeToRetry(e.err)
 }
 
 func (e *ErrTimeout) Unwrap() error {

--- a/pgconn.go
+++ b/pgconn.go
@@ -219,7 +219,7 @@ func connect(ctx context.Context, config *Config, fallbackConfig *FallbackConfig
 	if err != nil {
 		var netErr net.Error
 		if errors.As(err, &netErr) && netErr.Timeout() {
-			err = &ErrTimeout{err: err}
+			err = &errTimeout{err: err}
 		}
 		return nil, &connectError{config: config, msg: "dial error", err: err}
 	}
@@ -470,7 +470,7 @@ func (pgConn *PgConn) peekMessage() (pgproto3.BackendMessage, error) {
 		if !(isNetErr && netErr.Timeout()) {
 			pgConn.asyncClose()
 		} else if isNetErr && netErr.Timeout() {
-			err = &ErrTimeout{err: err}
+			err = &errTimeout{err: err}
 		}
 
 		return nil, err
@@ -490,7 +490,7 @@ func (pgConn *PgConn) receiveMessage() (pgproto3.BackendMessage, error) {
 		if !(isNetErr && netErr.Timeout()) {
 			pgConn.asyncClose()
 		} else if isNetErr && netErr.Timeout() {
-			err = &ErrTimeout{err: err}
+			err = &errTimeout{err: err}
 		}
 
 		return nil, err


### PR DESCRIPTION
These changes address [pgx issue #831](https://github.com/jackc/pgx/issues/831) by wrapping timeout errors in a new error type, `ErrTimeout`. In the issue thread, @atombender [summed up the issue and the solution](https://github.com/jackc/pgx/issues/831#issuecomment-819881537) implemented by these changes:

>The problem is distinguishing the error from a cancellation that occurs for other reasons. pgconn.Timeout() tests for context.Cancelled, which isn't universally a timeout signal.
>
> The only way to use pgconn.Timeout() "safely" is to always use it immediately on errors returned by pgx (or pgconn, etc.). If you wrap or pass the error on to higher-level layers, those layers can no longer know if the error came from pgx.
>
> This would really benefit from being wrapped in some special error type at the origin, in pgx. Otherwise we'll have to do this in every single pgx call:
>
> ```go
> func FetchStuff() (Data, error) {
>   // ...
>   if err := rows.Err(); err != nil {
>     return nil, convertError(err)
>   }
>   // ...
> }
>
> func convertError(err error) error {
>   if pgconn.Timeout(err) {
>     return ErrPostgresTimeout
>   }
>   return err
> }
>
> var ErrPostgresTimeout = errors.New("timeout")
> ```