### PR TITLE
removed lines to read conn to avoid blocking when called Close

### DIFF
--- a/pgconn.go
+++ b/pgconn.go
@@ -578,7 +578,6 @@ func (pgConn *PgConn) Close(ctx context.Context) error {
 	//
 	// See https://github.com/jackc/pgx/issues/637
 	pgConn.conn.Write([]byte{'X', 0, 0, 0, 4})
-	pgConn.conn.Read(make([]byte, 1))
 
 	return pgConn.conn.Close()
 }
@@ -605,7 +604,6 @@ func (pgConn *PgConn) asyncClose() {
 		pgConn.conn.SetDeadline(deadline)
 
 		pgConn.conn.Write([]byte{'X', 0, 0, 0, 4})
-		pgConn.conn.Read(make([]byte, 1))
 	}()
 }
 


### PR DESCRIPTION
## Problem

This problem occurs when a relay server is used to connect to PostgreSQL.
It is thought that the relay server reads the EOF first, so the read method is always in a wait state.

[io.Copy](https://pkg.go.dev/io#Copy) is used in the relay server to relay the connection between client and server. However, io.Copy has the property of not seeing EOF.

> A successful Copy returns err == nil, not err == EOF. Because Copy is defined to read from src until EOF, it does not treat an EOF from Read as an error to be reported.

So It should not be expected that the server will always return EOF.

If server will not respond EOF, these code always blocking when sent termination message because the postgresql server is not respond any message.

## Fix

See some postgresql clients implementation. there is not waiting to read any responses in some code.

- github.com/postgres/postgres
  - https://github.com/postgres/postgres/blob/88cbbbfa3e2b0d38d6047af83764f140face5991/src/interfaces/libpq/fe-connect.c#L4185-L4190
- in github.com/lib/pq
  - https://github.com/lib/pq/blob/9e747ca50601fcb6c958dd89f4cb8aea3e067767/conn.go#L833-L849