### PR TITLE
Legec lru context

### DIFF
--- a/stmtcache/lru.go
+++ b/stmtcache/lru.go
@@ -53,6 +53,14 @@ func (c *LRU) Get(ctx context.Context, sql string) (*pgconn.StatementDescription
 		}
 	}
 
+	if ctx != context.Background() {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+	}
+
 	if el, ok := c.m[sql]; ok {
 		c.l.MoveToFront(el)
 		return el.Value.(*pgconn.StatementDescription), nil


### PR DESCRIPTION
When getting a statement from the LRU cache with an expired context :

* if statement isn't present in the LRU cache, at some point a check is run on the context state, and an error is returned ;
* if the statement *is* present in the LRU cache, the current code path doesn't check the context state, and no error is returned to the caller

Although not technically a bug, it leads to surprising behaviors, such as https://github.com/jackc/pgx/issues/1107

If I understand correctly, returning an error when the context is already expired fits the expectations on `LRU.Get(ctx, sql)`, so I suggest to explicitly check for this case.