### PR TITLE
Fix TLS connection timeout

### DIFF
--- a/pgconn.go
+++ b/pgconn.go
@@ -239,7 +239,7 @@ func connect(ctx context.Context, config *Config, fallbackConfig *FallbackConfig
 		return nil, &connectError{config: config, msg: "dial error", err: err}
 	}
 
-	pgConn.contextWatcher = contextWatcher(netConn)
+	pgConn.contextWatcher = newContextWatcher(netConn)
 	pgConn.contextWatcher.Watch(ctx)
 	defer pgConn.contextWatcher.Unwatch()
 
@@ -254,7 +254,7 @@ func connect(ctx context.Context, config *Config, fallbackConfig *FallbackConfig
 		}
 
 		pgConn.contextWatcher.Unwatch()
-		pgConn.contextWatcher = contextWatcher(tlsConn)
+		pgConn.contextWatcher = newContextWatcher(tlsConn)
 		pgConn.contextWatcher.Watch(ctx)
 
 		pgConn.conn = tlsConn
@@ -348,7 +348,7 @@ func connect(ctx context.Context, config *Config, fallbackConfig *FallbackConfig
 	}
 }
 
-func contextWatcher(conn net.Conn) *ctxwatch.ContextWatcher {
+func newContextWatcher(conn net.Conn) *ctxwatch.ContextWatcher {
 	return ctxwatch.NewContextWatcher(
 		func() { conn.SetDeadline(time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)) },
 		func() { conn.SetDeadline(time.Time{}) },
@@ -1718,7 +1718,7 @@ func Construct(hc *HijackedConn) (*PgConn, error) {
 		cleanupDone: make(chan struct{}),
 	}
 
-	pgConn.contextWatcher = contextWatcher(pgConn.conn)
+	pgConn.contextWatcher = newContextWatcher(pgConn.conn)
 
 	return pgConn, nil
 }

--- a/pgconn.go
+++ b/pgconn.go
@@ -239,9 +239,7 @@ func connect(ctx context.Context, config *Config, fallbackConfig *FallbackConfig
 		return nil, &connectError{config: config, msg: "dial error", err: err}
 	}
 
-	pgConn.status = connStatusConnecting
 	pgConn.conn = netConn
-
 	pgConn.contextWatcher = newContextWatcher(netConn)
 	pgConn.contextWatcher.Watch(ctx)
 
@@ -253,15 +251,15 @@ func connect(ctx context.Context, config *Config, fallbackConfig *FallbackConfig
 			return nil, &connectError{config: config, msg: "tls error", err: err}
 		}
 
+		pgConn.conn = tlsConn
 		pgConn.contextWatcher = newContextWatcher(tlsConn)
 		pgConn.contextWatcher.Watch(ctx)
-
-		pgConn.conn = tlsConn
 	}
 
 	defer pgConn.contextWatcher.Unwatch()
 
 	pgConn.parameterStatuses = make(map[string]string)
+	pgConn.status = connStatusConnecting
 	pgConn.frontend = config.BuildFrontend(pgConn.conn, pgConn.conn)
 
 	startupMsg := pgproto3.StartupMessage{


### PR DESCRIPTION
Follow up to https://github.com/jackc/pgconn/pull/93 which fixes the test case. Re-uses the same code with minor changes to fix the bugs:

* Assigns `pgConn.conn` after the TLS connection is made to avoid the confusion around assigning within `startTLS`
* Fixes the timeouts in the test which was failing (it was closing too early with 50 microseconds when I believe the other PR had intended to use 50 milliseconds instead)
