### PR TITLE
Fix documentation saying only one IP from a hostname is used

### DIFF
--- a/config.go
+++ b/config.go
@@ -176,8 +176,6 @@ func NetworkAddress(host string, port uint16) (network, address string) {
 //
 // Other known differences with libpq:
 //
-// If a host name resolves into multiple addresses, libpq will try all addresses. pgconn will only try the first.
-//
 // When multiple hosts are specified, libpq allows them to have different passwords set via the .pgpass file. pgconn
 // does not.
 //

--- a/pgconn.go
+++ b/pgconn.go
@@ -99,7 +99,7 @@ type PgConn struct {
 }
 
 // Connect establishes a connection to a PostgreSQL server using the environment and connString (in URL or DSN format)
-// to provide configuration. See documention for ParseConfig for details. ctx can be used to cancel a connect attempt.
+// to provide configuration. See documentation for ParseConfig for details. ctx can be used to cancel a connect attempt.
 func Connect(ctx context.Context, connString string) (*PgConn, error) {
 	config, err := ParseConfig(connString)
 	if err != nil {
@@ -154,7 +154,7 @@ func ConnectConfig(ctx context.Context, config *Config) (pgConn *PgConn, err err
 			break
 		} else if pgerr, ok := err.(*PgError); ok {
 			err = &connectError{config: config, msg: "server error", err: pgerr}
-			ERRCODE_INVALID_PASSWORD := "28P01"                    // worng password
+			ERRCODE_INVALID_PASSWORD := "28P01"                    // wrong password
 			ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION := "28000" // db does not exist
 			if pgerr.Code == ERRCODE_INVALID_PASSWORD || pgerr.Code == ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION {
 				break


### PR DESCRIPTION
I noticed that the documentation says that only one IP will be used if a server is specified using a hostname. However, reading the code suggests that we resolve the host upon connect and try all of the IPs - as of #14 - using `expandWithIPs()`. Possibly I'm wrong, but I thought I'd send a quick PR because of this.

Thank you for the great project by the way!