### PR TITLE
fix detection of database does not exist error during connect

### DIFF
--- a/pgconn.go
+++ b/pgconn.go
@@ -154,9 +154,12 @@ func ConnectConfig(ctx context.Context, config *Config) (pgConn *PgConn, err err
 			break
 		} else if pgerr, ok := err.(*PgError); ok {
 			err = &connectError{config: config, msg: "server error", err: pgerr}
-			ERRCODE_INVALID_PASSWORD := "28P01"                    // wrong password
-			ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION := "28000" // db does not exist
-			if pgerr.Code == ERRCODE_INVALID_PASSWORD || pgerr.Code == ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION {
+			const ERRCODE_INVALID_PASSWORD = "28P01"                    // wrong password
+			const ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION = "28000" // wrong password or bad pg_hba.conf settings
+			const ERRCODE_INVALID_CATALOG_NAME = "3D000"                // db does not exist
+			if pgerr.Code == ERRCODE_INVALID_PASSWORD ||
+				pgerr.Code == ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION ||
+				pgerr.Code == ERRCODE_INVALID_CATALOG_NAME {
 				break
 			}
 		}


### PR DESCRIPTION
The code had a comment impliying that error 28000 was for DB does not exist,
but that wasn't actually correct. PR corrects the comment on that, and adds
a check for the correct error code for the DB not existing.