### PR TITLE
Fix: setting krbspn and krbsrvname didn't work

### DIFF
--- a/config.go
+++ b/config.go
@@ -41,7 +41,9 @@ type Config struct {
 	BuildFrontend  BuildFrontendFunc
 	RuntimeParams  map[string]string // Run-time parameters to set on connection as session default values (e.g. search_path or application_name)
 
-	Fallbacks []*FallbackConfig
+	KerberosSrvName string
+	KerberosSpn     string
+	Fallbacks       []*FallbackConfig
 
 	// ValidateConnect is called during a connection attempt after a successful authentication with the PostgreSQL server.
 	// It can be used to validate that the server is acceptable. If this returns an error the connection is closed and the next
@@ -263,6 +265,14 @@ func ParseConfig(connString string) (*Config, error) {
 		"min_read_buffer_size": {},
 		"service":              {},
 		"servicefile":          {},
+	}
+
+	// Adding kerberos configuration
+	if _, present := settings["krbsrvname"]; present {
+		config.KerberosSrvName = settings["krbsrvname"]
+	}
+	if _, present := settings["krbspn"]; present {
+		config.KerberosSpn = settings["krbspn"]
 	}
 
 	for k, v := range settings {

--- a/krb5.go
+++ b/krb5.go
@@ -41,14 +41,14 @@ func (c *PgConn) gssAuth() error {
 	}
 
 	var nextData []byte
-	if spn, ok := c.config.RuntimeParams["krbspn"]; ok {
+	if c.config.KerberosSpn != "" {
 		// Use the supplied SPN if provided.
-		nextData, err = cli.GetInitTokenFromSPN(spn)
+		nextData, err = cli.GetInitTokenFromSPN(c.config.KerberosSpn)
 	} else {
 		// Allow the kerberos service name to be overridden
 		service := "postgres"
-		if val, ok := c.config.RuntimeParams["krbsrvname"]; ok {
-			service = val
+		if c.config.KerberosSrvName != "" {
+			service = c.config.KerberosSrvName
 		}
 		nextData, err = cli.GetInitToken(c.config.Host, service)
 	}


### PR DESCRIPTION
I tried to connect to postgres using kerberos, but setting url parameters krbsrvname and krbspn did'n change anything. Now it is working

See https://github.com/otan/gopgkrb5/issues/1