### PR TITLE
fix GSSAPI authentication

### DIFF
--- a/config.go
+++ b/config.go
@@ -257,8 +257,6 @@ func ParseConfig(connString string) (*Config, error) {
 		"sslkey":               {},
 		"sslcert":              {},
 		"sslrootcert":          {},
-		"krbspn":               {},
-		"krbsrvname":           {},
 		"target_session_attrs": {},
 		"min_read_buffer_size": {},
 		"service":              {},


### PR DESCRIPTION
Accidentally included these two variables in the `notRuntimeParams` map,
probably an undo accident before committing. Unfortunate side effect of
having everything in separate repos (I tested it using an older revision).