### PR TITLE
Stop ignoring ErrorResponse during SCRAM auth

### DIFF
--- a/auth_scram.go
+++ b/auth_scram.go
@@ -78,12 +78,14 @@ func (c *PgConn) rxSASLContinue() (*pgproto3.AuthenticationSASLContinue, error) 
 	if err != nil {
 		return nil, err
 	}
-	saslContinue, ok := msg.(*pgproto3.AuthenticationSASLContinue)
-	if ok {
-		return saslContinue, nil
+	switch m := msg.(type) {
+	case *pgproto3.AuthenticationSASLContinue:
+		return m, nil
+	case *pgproto3.ErrorResponse:
+		return nil, ErrorResponseToPgError(m)
 	}
 
-	return nil, errors.New("expected AuthenticationSASLContinue message but received unexpected message")
+	return nil, fmt.Errorf("expected AuthenticationSASLContinue message but received unexpected message %T", msg)
 }
 
 func (c *PgConn) rxSASLFinal() (*pgproto3.AuthenticationSASLFinal, error) {
@@ -91,12 +93,14 @@ func (c *PgConn) rxSASLFinal() (*pgproto3.AuthenticationSASLFinal, error) {
 	if err != nil {
 		return nil, err
 	}
-	saslFinal, ok := msg.(*pgproto3.AuthenticationSASLFinal)
-	if ok {
-		return saslFinal, nil
+	switch m := msg.(type) {
+	case *pgproto3.AuthenticationSASLFinal:
+		return m, nil
+	case *pgproto3.ErrorResponse:
+		return nil, ErrorResponseToPgError(m)
 	}
 
-	return nil, errors.New("expected AuthenticationSASLFinal message but received unexpected message")
+	return nil, fmt.Errorf("expected AuthenticationSASLFinal message but received unexpected message %T", msg)
 }
 
 type scramClient struct {


### PR DESCRIPTION
The server may send back an ErrorResponse during SCRAM auth, and these
messages may contain useful information that described why
authentication failed. For example, if the password was invalid.