### PR TITLE
fix: wait for CopyInResponse before sending data

### DIFF
--- a/pgconn.go
+++ b/pgconn.go
@@ -1191,6 +1191,22 @@ func (pgConn *PgConn) CopyTo(ctx context.Context, w io.Writer, sql string) (Comm
 		return nil, &writeError{err: err, safeToRetry: n == 0}
 	}
 
+	// Wait for CopyIn response before sending data. This prevents the frontend
+	// from sending data before the backend has indicated that it is ready for it.
+	msg, err := pgConn.receiveMessage()
+	if err != nil {
+		pgConn.asyncClose()
+		return nil, preferContextOverNetTimeoutError(ctx, err)
+	}
+	switch msg := msg.(type) {
+	case *pgproto3.CopyInResponse:
+		// This is the expected response. Continue with the copy operation.
+	case *pgproto3.ErrorResponse:
+		return nil, ErrorResponseToPgError(msg)
+	default:
+		return nil, fmt.Errorf("received unexpected response to COPY command: %v", msg)
+	}
+
 	// Read results
 	var commandTag CommandTag
 	var pgErr error


### PR DESCRIPTION
According to https://www.postgresql.org/docs/14/protocol-flow.html#id-1.10.5.7.4 the frontend should check for a `CopyInResponse` before it starts sending `CopyData` messages to the backend.

This sometimes causes issues with our [PostgreSQL proxy](https://github.com/GoogleCloudPlatform/pgadapter), as it might receive `CopyData` messages before it is ready for it. We will look into whether we can handle this situation in our proxy as well.