### PR TITLE
Enable failover efforts when pg_hba.conf disallows non-ssl connections

### DIFF
--- a/pgconn.go
+++ b/pgconn.go
@@ -176,7 +176,7 @@ func ConnectConfig(octx context.Context, config *Config) (pgConn *PgConn, err er
 			const ERRCODE_INVALID_CATALOG_NAME = "3D000"                // db does not exist
 			const ERRCODE_INSUFFICIENT_PRIVILEGE = "42501"              // missing connect privilege
 			if pgerr.Code == ERRCODE_INVALID_PASSWORD ||
-				pgerr.Code == ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION ||
+				pgerr.Code == ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION && strings.Contains(pgerr.Message, "SSL on") ||
 				pgerr.Code == ERRCODE_INVALID_CATALOG_NAME ||
 				pgerr.Code == ERRCODE_INSUFFICIENT_PRIVILEGE {
 				break

--- a/pgconn.go
+++ b/pgconn.go
@@ -176,7 +176,7 @@ func ConnectConfig(octx context.Context, config *Config) (pgConn *PgConn, err er
 			const ERRCODE_INVALID_CATALOG_NAME = "3D000"                // db does not exist
 			const ERRCODE_INSUFFICIENT_PRIVILEGE = "42501"              // missing connect privilege
 			if pgerr.Code == ERRCODE_INVALID_PASSWORD ||
-				pgerr.Code == ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION && strings.Contains(pgerr.Message, "SSL on") ||
+				pgerr.Code == ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION && fc.TLSConfig != nil ||
 				pgerr.Code == ERRCODE_INVALID_CATALOG_NAME ||
 				pgerr.Code == ERRCODE_INSUFFICIENT_PRIVILEGE {
 				break


### PR DESCRIPTION
This could be a fix the allows for a resolution of #68 and [#1581](https://github.com/jackc/pgx/issues/1581). 

By breaking retries on error code 28000 we do not continue the functionality of libpq. This should allow for a more similar experience without breaking changes made in #68.


Here's an example of connections with the changes:

Conn string `postgres://ad:@0.0.0.0:5401,0.0.0.0:5402,0.0.0.0:5403/analytics?target_session_attrs=read-write`

> &{0.0.0.0 5401 0x1400017e480}
> failed to connect to `host=0.0.0.0 user=ad database=analytics`: ValidateConnect failed (read only connection)
> &{0.0.0.0 5401 <nil>}
> FATAL: no pg_hba.conf entry for host "172.20.0.1", user "ad", database "analytics", SSL off (SQLSTATE 28000)
> 
> &{0.0.0.0 5402 0x1400017e600}
> failed to connect to `host=0.0.0.0 user=ad database=analytics`: ValidateConnect failed (read only connection)
> &{0.0.0.0 5402 <nil>}
> FATAL: no pg_hba.conf entry for host "172.20.0.1", user "ad", database "analytics", SSL off (SQLSTATE 28000)
> 
> &{0.0.0.0 5403 0x1400017e780}

To expand this is first failing with SSL because of read only DBs and then continuing to fail on SSL for the automatically included fall backs. Bad password exit immediately.

> &{0.0.0.0 5401 0x1400017e480}
> FATAL: no pg_hba.conf entry for host "172.20.0.1", user "abbaba", database "analytics", SSL on (SQLSTATE 28000)
> 2023/06/23 14:51:01 Unable to connect to database: failed to connect to `host=0.0.0.0 user=abbaba database=analytics`: server error (FATAL: no pg_hba.conf entry for host "172.20.0.1", user "abbaba", database "analytics", SSL on (SQLSTATE 28000))
> exit status 1



