### PR TITLE
fixed issue where the password was being assigned to wrong config key 

### DIFF
--- a/config.go
+++ b/config.go
@@ -528,6 +528,12 @@ func parseDSNSettings(s string) (map[string]string, error) {
 		}
 
 		key = strings.Trim(s[:eqIdx], " \t\n\r\v\f")
+		s = s[eqIdx+1:]
+
+		if s[0] == ' ' && s[1] != '\'' {
+			settings[key] = ""
+			continue
+		}
 		s = strings.TrimLeft(s[eqIdx+1:], " \t\n\r\v\f")
 		if len(s) == 0 {
 		} else if s[0] != '\'' {

--- a/config_test.go
+++ b/config_test.go
@@ -79,6 +79,19 @@ func TestParseConfig(t *testing.T) {
 			},
 		},
 		{
+			name:       "DNS with empty password",
+			connString: "host=localhost user=jack password= dbname=mydb port=5432 sslmode=disable ",
+			config: &pgconn.Config{
+				User:          "jack",
+				Host:          "localhost",
+				Port:          5432,
+				Password:      "",
+				Database:      "mydb",
+				TLSConfig:     nil,
+				RuntimeParams: map[string]string{},
+			},
+		},
+		{
 			name:       "sslmode allow",
 			connString: "postgres://jack:secret@localhost:5432/mydb?sslmode=allow",
 			config: &pgconn.Config{


### PR DESCRIPTION
Previously when on DNS connection string when empty password was passed . It was being assigned to wrong config key.
For e.g `host=localhost user=jack password= dbname=mydb port=5432 sslmode=disable ` used to generate password as `dbname=mydb`. This PR tries to fix this. Not sure if this would be right way to fix it though . All the tests were passing