### PR TITLE
Stop fallback checks after first timeout error

### DIFF
--- a/pgconn.go
+++ b/pgconn.go
@@ -188,6 +188,10 @@ func ConnectConfig(octx context.Context, config *Config) (pgConn *PgConn, err er
 			if _, ok := cerr.err.(*NotPreferredError); ok {
 				fallbackConfig = fc
 			}
+			if _, ok := cerr.err.(*errTimeout); ok {
+				// once we reach timeout it's useless to check other fallbacks
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixing IPV4 error for dualstack cluster without IPV6 connectivity #139